### PR TITLE
2015資料の誤っている気がするところ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1640,14 +1640,14 @@ fetch('/api/foo').then(fetchBar(fetchBuz(doSomething)));
 function fetchBar(callback) {
   return function(responseFoo) {
     doSomething(responseFoo);
-    fetchBar(callback);
+    fetch('/api/bar').then(callback);
   };
 }
 
 function fetchBuz(callback) {
   return function(responseBar) {
     doSomething(responseBar);
-    fetchBuz(callback);
+    fetch('/api/buz').then(callback);
   };
 }
 ```

--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ button 要素に `addEventListener` すればよいように
 
 
 `addEventListener` の引数で  
-1-2-4 か 1-3-4 のどちらかを選べます。
+1-2-4 か 2-3-4 のどちらかを選べます。
 
 1. capturing フェーズ
 


### PR DESCRIPTION
READMEに誤りを見つけた気がしますのでPRを送ります。
- event phase
  - バブリングフェーズで target -> bubbling ではなくて caputuring -> bubbling となっているのを修正
- クロージャー + 継続渡しスタイル のプログラムのミス修正

私の勘違いでしたら申し訳ありません
