### PR TITLE
Fixed typographical error, changed accidentaly to accidentally in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,7 +1389,7 @@ y で読み込ませます。
 
 
 
-##### 12. would you like to mark this package as private which prevents it from being accidentaly published to the registry?
+##### 12. would you like to mark this package as private which prevents it from being accidentally published to the registry?
 
 bower のレジストリへ登録できないようにするか  
 どうか指定します。


### PR DESCRIPTION
mixi-inc, I've corrected a typographical error in the documentation of the [JavaScriptTraining](https://github.com/mixi-inc/JavaScriptTraining) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
