### PR TITLE
"initMouseEvent()" has been removed from the Web standards.

### DIFF
--- a/public/stage4/tests.js
+++ b/public/stage4/tests.js
@@ -103,8 +103,7 @@ describe('ステージ4（意図通りにイベントを利用できる）', fun
 
 function createClickEvent() {
   var event = document.createEvent('MouseEvents');
-  event.initMouseEvent('click', true, true, window,
-                       0, 0, 0, 80, 20, false, false, false, false, 0, null);
+  event.initEvent('click', false, true);
   return event;
 }
 


### PR DESCRIPTION
Thank you very much for your wonderful teaching.

About,  It's written in [MDN- MouseEvent.initMouseEvent()](https://developer.mozilla.org/ja/docs/Web/API/MouseEvent/initMouseEvent). 

I think I'd like the one using `event.initEvent()` instead of `MouseEvent.initMouseEvent()`.
